### PR TITLE
Bump flutter_hooks version to 0.19.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  flutter_hooks: ^0.18.5+1
+  flutter_hooks: ^0.19.0
 
 dev_dependencies:
   flutter_lints: ^2.0.1


### PR DESCRIPTION
Resolves version solving failure by upgrading the flutter_hooks dependency version to the latest version.