### PR TITLE
feat: support flutter 3.16

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,13 +28,13 @@ jobs:
       - name: Get dependencies
         run: |
           dart pub global activate melos
-          melos run pub:get
+          melos get
 
       - name: Run tests for our dart project.
         run: |
-          melos run unit:test
+          melos test
 
       - name: Check for any formatting and statically analyze the code.
         run: |
-          melos run format
-          melos run analyze
+          melos format
+          melos analyze

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-dart 3.0.6
-flutter 3.10.6-stable
+dart 3.2.0
+flutter 3.16.0-stable

--- a/lib/flutter_hooks_test.dart
+++ b/lib/flutter_hooks_test.dart
@@ -56,7 +56,7 @@ class _HookTestingAction<T, P> {
 Future<void> _build(Widget widget) async {
   final binding = TestWidgetsFlutterBinding.ensureInitialized();
   return TestAsyncUtils.guard<void>(() {
-    binding.attachRootWidget(widget);
+    binding.attachRootWidget(binding.wrapWithDefaultView(widget));
     binding.scheduleFrame();
     return binding.pump();
   });

--- a/melos.yaml
+++ b/melos.yaml
@@ -1,7 +1,7 @@
 name: flutter_use
 
 packages:
-  - '**'
+  - .
   - example/**
 
 ide:


### PR DESCRIPTION
### Problem
```
══╡ EXCEPTION CAUGHT BY FLUTTER FRAMEWORK ╞═════════════════════════════════════════════════════════
The following assertion was thrown:
The render object for LimitedBox cannot find ancestor render object to attach to.
The ownership chain for the RenderObject in question was:
  LimitedBox ← Container ← HookBuilder ← [root]
Try wrapping your widget in a View widget or any other widget that is backed by a
RenderTreeRootElement to serve as the root of the render tree.
════════════════════════════════════════════════════════════════════════════════════════════════════
00:05 +1 -1: Using flutter_hooks_test [E]                                                                                                                                                              
  Test failed. See exception logs above.
  The test description was: Using flutter_hooks_test
```

Tests with flutter_hooks_test will cause above exception since Flutter 3.16.0.
This is affected by https://github.com/flutter/flutter/pull/125003.

### What does this change?
Wrap widget which is built in buildHook with `View`.
This is same behavior with `WidgetTester.pumpWidget` [^1].

In addition to that, update Melos configuration and GitHub Actions workflow.

[^1]: https://github.com/flutter/flutter/blob/db7ef5bf9f59442b0e200a90587e8fa5e0c6336a/packages/flutter_test/lib/src/widget_tester.dart#L576
